### PR TITLE
chore(ci): remove pre-commit cache restore key

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -266,8 +266,6 @@ jobs:
           path: |
             ${{ env.PRE_COMMIT_HOME }}
           key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pre-commit-
 
       - name: Set up uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb  # v6.1.0


### PR DESCRIPTION
Pre-commit does not clean up any files, resulting in the cache bloating indefinitely.