### PR TITLE
chore: prefer prek over pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
       - typecheck
       - test
       - spelling
-      - pre-commit
+      - prek
 
     steps:
       - name: Failed
@@ -249,38 +249,35 @@ jobs:
       - name: Spell Check Repo
         uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee  # v1.36.2
 
-  pre-commit:
-    name: Pre-commit
+  prek:
+    name: Prek (pre-commit)
 
     runs-on: ubuntu-latest
-
-    env:
-      PRE_COMMIT_HOME: ${{ github.workspace }}/.pre-commit
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
-      - name: Cache pre-commit
+      - name: Cache prek
         uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809  # v4.2.4
         with:
           path: |
-            ${{ env.PRE_COMMIT_HOME }}
-          key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            $HOME/.cache/prek
+          key: ${{ runner.os }}-prek-${{ hashFiles('.pre-commit-config.yaml') }}
 
       - name: Set up uv
         uses: astral-sh/setup-uv@557e51de59eb14aaaba2ed9621916900a91d50c6  # v6.6.1
         with:
           enable-cache: true
-          cache-suffix: pre-commit
+          cache-suffix: prek
           cache-dependency-glob: ''
 
-      - name: Install pre-commit
-        run: uv tool install pre-commit
+      - name: Install prek
+        run: uv tool install prek
       - name: Install hatch
         run: uv tool install hatch
 
-      - name: Run pre-commit
-        run: pre-commit run --show-diff-on-failure --color=always --all-files
+      - name: Run prek
+        run: prek run --show-diff-on-failure --color=always --all-files
 
   committed:
     name: Committed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,7 @@
 ---
 default_install_hook_types:
-  - commit-msg
-  - post-checkout
   - pre-commit
   - pre-push
-  - prepare-commit-msg
 
 # Unless otherwise specified, all hooks below are run during pre-commit.
 default_stages:


### PR DESCRIPTION
Prek is an alternative to `pre-commit` which is implemented in Rust and has a large number of improvements (most of all, the main developer behind it is actually open to suggestions).