### PR TITLE
chore: update lint tooling

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,12 +1,10 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.5.6/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "formatter": {

--- a/prek.toml
+++ b/prek.toml
@@ -40,15 +40,15 @@ hooks = [
 
 [[repos]]
 repo  = "https://github.com/biomejs/pre-commit"
-rev   = "v2.4.12"
+rev   = "v2.5.6"
 hooks = [
-  { id = "biome-check", additional_dependencies = ["@biomejs/biome@1.9.2"] },
+  { id = "biome-check" },
 ]
 
 # TOML formatting (tombi replaces taplo)
 [[repos]]
 repo  = "https://github.com/tombi-toml/tombi-pre-commit"
-rev   = "v0.9.9"
+rev   = "v1.2.6"
 hooks = [
   { id = "tombi-format", exclude = '(^|/)Cargo\.lock$' },
   { id = "tombi-lint" },
@@ -56,9 +56,9 @@ hooks = [
 
 [[repos]]
 repo  = "https://github.com/astral-sh/ruff-pre-commit"
-rev   = "v0.15.11"
+rev   = "v0.16.1"
 hooks = [
-  { id = "ruff", args = ["--fix", "--exit-non-zero-on-fix"] },
+  { id = "ruff-check", args = ["--fix", "--exit-non-zero-on-fix"] },
   { id = "ruff-format" },
 ]
 
@@ -71,28 +71,28 @@ hooks = [
 
 [[repos]]
 repo  = "https://github.com/DavidAnson/markdownlint-cli2"
-rev   = "v0.22.0"
+rev   = "v0.23.2"
 hooks = [
   { id = "markdownlint-cli2" },
 ]
 
 [[repos]]
 repo  = "https://github.com/crate-ci/typos"
-rev   = "v1.45.1"
+rev   = "v1.48.0"
 hooks = [
   { id = "typos" },
 ]
 
 [[repos]]
 repo  = "https://github.com/shellcheck-py/shellcheck-py"
-rev   = "v0.10.0.1"
+rev   = "v0.11.0.1"
 hooks = [
   { id = "shellcheck", args = ["--external-sources"] },
 ]
 
 [[repos]]
 repo  = "https://github.com/scop/pre-commit-shfmt"
-rev   = "v3.11.0-1"
+rev   = "v3.13.1-1"
 hooks = [
   { id = "shfmt" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
 
 [dependency-groups]
 devel = [
-  "ruff==0.15.22",
+  "ruff==0.16.1",
   { include-group = "test" },
   { include-group = "types" },
 ]
@@ -158,6 +158,7 @@ build-backend = "hatchling.build"
     ignore = [
       "A001",  # Forbid assigning built-ins
       "A002",  # Forbid shadowing built-ins
+      "CPY001",  # Require a copyright notice at the top of each file
       "D200",  # Require single line docstrings to be on one line.
       "D203",  # Require blank line before class docstring
       "D212",  # Multi-line docstring summary must start at the first line


### PR DESCRIPTION
Rolls the prek hook revisions forward (`prek auto-update`, which Renovate does not manage) and takes ruff 0.16.1, superseding #341.

## Ruff 0.16.1

The dev dependency pin and the prek hook rev move together. Two consequences:

- **CPY001 is now stable** and fires on all 18 Python files, demanding a copyright notice at the top of each. This project does not want that, so it is ignored globally in `pyproject.toml` rather than fixed.
- **`ruff` is now a legacy hook alias**, renamed to `ruff-check`.

No other new diagnostics surfaced under `select = ["ALL"]`, and the formatter produced no changes.

## Biome

`biome-check` pinned `additional_dependencies = ["@biomejs/biome@1.9.2"]`, dating from when the pre-commit hook was versioned independently of biome itself. That is no longer true, so the pin only served to hold the tool at 1.9.2 while the hook rev advanced — every biome bump Renovate landed was inert.

Dropping the pin moves biome to 2.x, which required migrating `biome.json` (`biome migrate`): `organizeImports` became an assist action, and `rules.recommended` became `rules.preset`.

## Other hook bumps

tombi v0.9.9 → v1.2.6, markdownlint-cli2 v0.22.0 → v0.23.2, typos v1.45.1 → v1.48.0, shellcheck-py v0.10.0.1 → v0.11.0.1, shfmt v3.11.0-1 → v3.13.1-1.

## Verification

`prek run --all-files` passes clean, and the test suite passes (31 passed).